### PR TITLE
Tile at efficiency

### DIFF
--- a/Labyrinth/src/LabyrinthOriginal/GameMaster.java
+++ b/Labyrinth/src/LabyrinthOriginal/GameMaster.java
@@ -17,7 +17,7 @@ public class GameMaster {
 	public static void gameStartUp() {
 		Board b = newBoard(5,5);
 		
-		b.addPlayer(new Player(b.getTiles().get(1),Color.green));
+		b.addPlayer(new Player(b.tileAt(0,0),Color.green));
 		
 		JFrame f = new JFrame();
 		f.setContentPane(new BoardDisplayer(b));

--- a/Labyrinth/src/LabyrinthOriginal/GameMaster.java
+++ b/Labyrinth/src/LabyrinthOriginal/GameMaster.java
@@ -17,7 +17,7 @@ public class GameMaster {
 	public static void gameStartUp() {
 		Board b = newBoard(5,5);
 		
-		b.addPlayer(new Player(2,2,Color.green));
+		b.addPlayer(new Player(b.getTiles().get(1),Color.green));
 		
 		JFrame f = new JFrame();
 		f.setContentPane(new BoardDisplayer(b));

--- a/Labyrinth/src/Physics/Board.java
+++ b/Labyrinth/src/Physics/Board.java
@@ -148,6 +148,10 @@ public class Board {
 		this.tiles = t;
 	}
 	
+	public ArrayList<Tile> getTiles() {
+		return this.tiles;
+	}
+	
 	public void addPlayer(Player p) {
 		this.players.add(p);
 	}
@@ -162,7 +166,7 @@ public class Board {
 	public boolean movePlayer(Player p, int direction){
 		if (checkMove(p, direction)){
 			Point newLocation = Directions.move(p.location(),direction);
-			p.moveTo(newLocation);
+			p.moveTo(this.tileAt(newLocation));
 			alertListeners();
 			return true;
 		}
@@ -171,8 +175,8 @@ public class Board {
 	
 	public boolean checkMove(Player p, int direction){
 		Point newLocation = Directions.move(p.location(),direction);
-		Tile fromTile = tileAt(p.location());
-		if (fromTile == null){
+		Tile fromTile = p.getTile();
+		if (fromTile == null) { //This probably is no longer necessary.
 			return true;
 		}
 		Tile toTile = tileAt(newLocation);

--- a/Labyrinth/src/Physics/BoardDisplayer.java
+++ b/Labyrinth/src/Physics/BoardDisplayer.java
@@ -68,7 +68,7 @@ public class BoardDisplayer extends JPanel implements ChangeListener, KeyListene
 	public void paintCharacters(Graphics g){
 		for (Player c : board.players){
 			GuiPlayer gc = new GuiPlayer(c);
-			Point[] tlBr = screenBounds(c.x, c.y);
+			Point[] tlBr = screenBounds(c.location().x, c.location().y);
 			Point topLeft = tlBr[0];
 			Point bottomRight = tlBr[1];
 			gc.paint(g, topLeft, bottomRight);
@@ -216,7 +216,7 @@ public class BoardDisplayer extends JPanel implements ChangeListener, KeyListene
 		
 		
 		
-		b.players.add(new Player(2,2,Color.green));
+		b.players.add(new Player(tiles[1],Color.green));
 		
 		JFrame f = new JFrame();
 		f.setContentPane(new BoardDisplayer(b));

--- a/Labyrinth/src/Physics/BoardDisplayer.java
+++ b/Labyrinth/src/Physics/BoardDisplayer.java
@@ -56,7 +56,8 @@ public class BoardDisplayer extends JPanel implements ChangeListener, KeyListene
 	}
 	
 	private void paintTiles(Graphics g){
-		for (Tile t : board.tiles){
+		for (Point key : this.board.getTiles().keySet()){
+			Tile t = this.board.getTiles().get(key);
 			GuiTile gt = new GuiTile(t);
 			Point[] tlBr = screenBounds(t.x, t.y); //Screen boundaries of this tile
 			Point topLeft = tlBr[0];
@@ -211,7 +212,7 @@ public class BoardDisplayer extends JPanel implements ChangeListener, KeyListene
 		tiles[3].setUnblocked("Up", true);
 		
 		for (Tile t : tiles){
-			b.tiles.add(t);
+			b.tiles.put(t.location(),t);
 		}
 		
 		

--- a/Labyrinth/src/Physics/BoardTester.java
+++ b/Labyrinth/src/Physics/BoardTester.java
@@ -16,29 +16,29 @@ public class BoardTester {
 	Tile t2;
 	Tile t3;
 	Tile t4;
-	Tile t5;
+	Tile t5; 	
 
 	@Before
 	public void setUp() throws Exception {
-		/*  
-		 * Initial board state
+		  
+		 /* Initial board state
 		 * 
 		 *   T1  T2
 		 *   T3  T4
 		 *   T5
-		 *   
 		 */   
+		    
 		b = new Board();
 		t1 = new Tile(0,2);
 		t2 = new Tile(2,2);
 		t3 = new Tile(0,1);
 		t4 = new Tile(2,1);
 		t5 = new Tile(0,0);
-		b.tiles.add(t1);
-		b.tiles.add(t2);
-		b.tiles.add(t3);
-		b.tiles.add(t4);
-		b.tiles.add(t5);
+		b.tiles.put(t1.location(), t1);
+		b.tiles.put(t2.location(), t2);
+		b.tiles.put(t3.location(), t3);
+		b.tiles.put(t4.location(), t4);
+		b.tiles.put(t5.location(), t5);
 	}
 
 	@After
@@ -131,3 +131,4 @@ public class BoardTester {
 	}
 
 }
+

--- a/Labyrinth/src/Physics/Player.java
+++ b/Labyrinth/src/Physics/Player.java
@@ -3,24 +3,30 @@ import java.awt.Color;
 import java.awt.Point;
 
 public class Player {
-	int x;
-	int y;
+	Tile tile;
 	Color color;
 	
 	
-	public Player(int x, int y, Color c){
-		this.x = x;
-		this.y = y;
+	public Player(Tile t, Color c){
+		this.tile = t;
 		this.color = c;
 	}
 	
-	public void moveTo(Point p){
+	public void moveTo(Tile t) {
+		this.tile = t;
+	}
+	
+/*	public void moveTo(Point p){
 		this.x = p.x;
 		this.y = p.y;
 	}
+*/
+	public Tile getTile() {
+		return this.tile;
+	}
 	
 	public Point location(){
-		return new Point(this.x, this.y);
+		return this.tile.location();
 	}
 
 }

--- a/Labyrinth/src/Physics/Player.java
+++ b/Labyrinth/src/Physics/Player.java
@@ -16,11 +16,6 @@ public class Player {
 		this.tile = t;
 	}
 	
-/*	public void moveTo(Point p){
-		this.x = p.x;
-		this.y = p.y;
-	}
-*/
 	public Tile getTile() {
 		return this.tile;
 	}

--- a/Labyrinth/src/Physics/Tile.java
+++ b/Labyrinth/src/Physics/Tile.java
@@ -31,10 +31,15 @@ public class Tile {
 		return new Point(this.x, this.y);
 	}
 	
-	public void setLocation(Point p){
+	/* It would be nice if we could restrict this method to only be accessible to
+	 * Board method change tile location. Changing the location of a tile without 
+	 * changing its key in the tiles HashMap creates bugs!
+	 */
+	 public void setLocation(Point p){
 		this.x = p.x;
 		this.y = p.y;
-	}
+	 }
+	
 	
 	public boolean isUnblocked(String direction){
 		return isUnblocked(Directions.direction(direction));


### PR DESCRIPTION
Resolves issue #12 by changing the way the Board class stores tiles from an ArrayList<Tile> to a HashMap<Point, Tile> where a tile's key is it's x,y-location. Updates the rest of the code to accommodate this change. Note that once a tile is "on" a board, that tile's x,y-location should not be changed without also changing the key in the HashMap. In effort to avoid this, a new method in the Board class, changeTileLocation(), was made. This method changes the tile's location and changes the key in HashMap. Note that the Tile class method setLocation() cannot be made private because changeTileLocation() needs to use the method. Is there any way we can make setLocation only accessible to changeTileLocation?